### PR TITLE
fix: close unclosed GitHub Actions expression

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         app-name: 'vjs-pension-prod-func'
         package: './output'
-        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_PROD }
+        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_PROD }}
 
   release-please:
     needs: [test, deploy-dev]


### PR DESCRIPTION
- Fix missing closing }} for AZURE_FUNCTIONAPP_PUBLISH_PROFILE_PROD
- Resolve GitHub Actions workflow syntax error on line 92