### PR TITLE
fix: add required GitHub Actions permissions for release-please

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   test:
@@ -103,6 +104,7 @@ jobs:
           release-type: simple
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   post-release:
     needs: [deploy-prod]


### PR DESCRIPTION
- Add id-token: write permission for creating releases
- Explicitly set GITHUB_TOKEN for release-please action
- Resolve 'Resource not accessible by integration' error