### PR TITLE
fix: prevent dev deployment on release commits

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,7 +39,7 @@ jobs:
   deploy-dev:
     needs: test
     runs-on: ubuntu-latest
-    if: "github.ref == 'refs/heads/main'"
+    if: "github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main): release')"
     environment: dev
     
     steps:


### PR DESCRIPTION
- Skip dev deployment when commit contains 'chore(main): release'
- Ensure release merges only deploy to production
- Dev should already have latest code before release creation