### PR TITLE
fix: make Bruno test dynamic for any pension ID

### DIFF
--- a/api-tests/Get Pension by ID.bru
+++ b/api-tests/Get Pension by ID.bru
@@ -15,8 +15,13 @@ tests {
   
   test("Response contains pension data", function() {
     const data = res.getBody();
+    
+    // Extract the expected ID from the URL
+    const url = bru.getRequestUrl();
+    const expectedId = parseInt(url.split('/').pop());
+    
     expect(data).to.have.property('id');
-    expect(data.id).to.equal(3);
+    expect(data.id).to.equal(expectedId);
     expect(data).to.have.property('name');
     expect(data).to.have.property('age');
     expect(data).to.have.property('pensionStartDate');


### PR DESCRIPTION
- Extract expected ID from request URL dynamically
- Remove hardcoded ID 3 expectation
- Test will now pass for any valid pension ID (1, 2, or 3)
- Resolves test failures when testing different pension IDs