### PR TITLE
fix(ci-cd): correct production deployment trigger to use release even…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -39,7 +41,7 @@ jobs:
   deploy-dev:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main) release')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main) release')
     environment: dev
     
     steps:
@@ -69,7 +71,7 @@ jobs:
   deploy-prod:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'chore(main) release')
+    if: github.event_name == 'release' && github.event.action == 'published'
     environment: prod
     
     steps:
@@ -101,7 +103,7 @@ jobs:
     # Only creates release if there are conventional commits since last release
     needs: [test, deploy-dev]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main) release') && needs.deploy-dev.result == 'success'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main) release') && needs.deploy-dev.result == 'success'
     
     steps:
       - name: Run release-please
@@ -116,7 +118,7 @@ jobs:
   post-release:
     needs: [deploy-prod]
     runs-on: ubuntu-latest
-    if: needs.deploy-prod.result == 'success'
+    if: github.event_name == 'release' && github.event.action == 'published' && needs.deploy-prod.result == 'success'
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…ts instead of commit message detection

- Add 'release: published' trigger to workflow
- Update deploy-prod condition to trigger on release events
- Update deploy-dev condition to only run on push events
- Update release-please condition to only run on push events
- Fix post-release cleanup to trigger on release events

This resolves the issue where production deployments were not happening because the conditional logic was checking the wrong commit message.