### PR TITLE
fix(ci-cd): correct workflow to deploy prod only on release commits, …

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,8 +6,6 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -21,6 +19,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Run tests on all PRs and all pushes to main
     steps:
     - uses: actions/checkout@v4
     
@@ -41,7 +40,11 @@ jobs:
   deploy-dev:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'chore(main) release')
+    if: >
+      github.event_name == 'push' && 
+      github.ref == 'refs/heads/main' && 
+      !contains(github.event.head_commit.message, 'chore(main) release') &&
+      needs.test.result == 'success'
     environment: dev
     
     steps:
@@ -71,7 +74,11 @@ jobs:
   deploy-prod:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published'
+    if: >
+      github.event_name == 'push' && 
+      github.ref == 'refs/heads/main' && 
+      contains(github.event.head_commit.message, 'chore(main) release') &&
+      needs.test.result == 'success'
     environment: prod
     
     steps:
@@ -118,7 +125,11 @@ jobs:
   post-release:
     needs: [deploy-prod]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'published' && needs.deploy-prod.result == 'success'
+    if: >
+      github.event_name == 'push' && 
+      github.ref == 'refs/heads/main' && 
+      contains(github.event.head_commit.message, 'chore(main) release') &&
+      needs.deploy-prod.result == 'success'
     
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…not dev

- Regular PR merge to main: test + deploy-dev + release-please
- Release branch merge to main: test + deploy-prod + cleanup
- Remove release event triggers, use commit message detection
- Fix deploy-prod to depend on test and trigger on 'chore(main) release' commits
- Fix post-release cleanup to run after prod deployment